### PR TITLE
Supported device ID for W25Q128JV-IQ external flash

### DIFF
--- a/src/main/drivers/flash_w25q128.h
+++ b/src/main/drivers/flash_w25q128.h
@@ -26,6 +26,11 @@
 
 #include "stm32h7xx_hal.h"
 
+#define W25Q_MANUFACTURER_ID    0xEF //!< MF7 - MF0
+#define W25Q_DEVICE_ID_1_IQ     0x40 //!< W25Q128JV-IM - first part of ID15 - ID0 (4018h)
+#define W25Q_DEVICE_ID_1_IM     0x70 //!< W25Q128JV-IQ - first part of ID15 - ID0 (7018h)
+#define W25Q_DEVICE_ID_2        0x18 //!< W25Q128JV-Ix - second part of ID15 - ID0 (4018h or 7018h)
+
 // Device size parameters
 #define W25Q_PAGE_SIZE          256         //!< Bytes
 #define W25Q_SECTOR_SIZE        4096        //!< Bytes (4KB)

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -182,7 +182,11 @@ void detectFlashAndEnableMemoryMap(void)
 
     W25q_readJedec(&hqspi, response);
 
-    bool haveJedecId = (response[0] == 0xEF && response[1] == 0x70 && response[2] == 0x18 );
+    bool haveJedecId = (
+            (response[0] == W25Q_MANUFACTURER_ID) &&
+            ((response[1] == W25Q_DEVICE_ID_1_IQ) || (response[1] == W25Q_DEVICE_ID_1_IM)) &&
+            (response[2] == W25Q_DEVICE_ID_2)
+            );
 
     if (!haveJedecId) {
         return;


### PR DESCRIPTION
W25Q128JV-**IM** and W25Q128JV-**IQ** have a bit different JEDEC, so the SSBL will not work if W25Q128JV-IQ is fitted to SP Racing Board. (for example, the last board shipped to me) 

![image](https://user-images.githubusercontent.com/10188706/94991758-5fbdde00-0585-11eb-927d-68789f2498c6.png)
